### PR TITLE
🧪 Add error path test for live trading get_data

### DIFF
--- a/live_trading/multi_bar.py
+++ b/live_trading/multi_bar.py
@@ -82,6 +82,9 @@ class TradingApp:
         Fetch 'n' bars of historical data for the given symbol and timeframe.
         """
         rates = mt5.copy_rates_from_pos(symbol, timeframe, 0, n)
+        if rates is None:
+            log_and_print(f"Could not retrieve data for {symbol}", is_error=True)
+            return None
         rates_frame = pd.DataFrame(rates)
         rates_frame['time'] = pd.to_datetime(rates_frame['time'], unit='s')
         rates_frame.set_index('time', inplace=True)

--- a/tests/test_multi_bar.py
+++ b/tests/test_multi_bar.py
@@ -1,0 +1,24 @@
+import sys
+from unittest.mock import MagicMock
+# Mock out MetaTrader5 before importing our module
+sys.modules['MetaTrader5'] = MagicMock()
+
+import unittest
+from unittest.mock import patch
+import pandas as pd
+from live_trading.multi_bar import TradingApp, log_and_print
+
+class TestTradingApp(unittest.TestCase):
+    def setUp(self):
+        self.app = TradingApp(symbol="EURUSD", lot_size=0.01, magic_number=123456)
+
+    @patch("live_trading.multi_bar.mt5.copy_rates_from_pos")
+    @patch("live_trading.multi_bar.log_and_print")
+    def test_get_data_returns_none(self, mock_log, mock_copy_rates):
+        mock_copy_rates.return_value = None
+
+        # Test what happens when mt5.copy_rates_from_pos returns None
+        result = self.app.get_data("EURUSD", 100, 16408)
+
+        self.assertIsNone(result)
+        mock_log.assert_called_once_with("Could not retrieve data for EURUSD", is_error=True)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing error path test for `get_data` in `live_trading/multi_bar.py` where `mt5.copy_rates_from_pos` might return `None`.

📊 **Coverage:** What scenarios are now tested
- Validates the error scenario where `mt5.copy_rates_from_pos` fails to return data.
- Ensures the error is correctly logged using `log_and_print`.
- Asserts that `get_data` immediately returns `None` to prevent further `pandas` indexing errors.

✨ **Result:** The improvement in test coverage
The code now safely handles and verifies API failures, preventing regressions in `live_trading/multi_bar.py` and boosting the reliability of the application's data loading phase.

---
*PR created automatically by Jules for task [7967918719390022721](https://jules.google.com/task/7967918719390022721) started by @maghdam*